### PR TITLE
Automate post-release asset verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,3 +243,22 @@ jobs:
       - name: Build (macOS)
         if: runner.os == 'macOS'
         run: npm run build:mac -- --publish always
+
+  verify-release:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Verify published release assets and feeds
+        run: npm run release:verify -- --tag "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}"

--- a/docs/ATUALIZACOES.md
+++ b/docs/ATUALIZACOES.md
@@ -45,12 +45,13 @@ Voce precisa:
 4. Commit e crie a tag semver correspondente no commit final.
 5. Push da tag: `git push origin <tag>`.
 6. O workflow `.github/workflows/release.yml` gera o corpo padronizado da release a partir de `docs/notas-da-versao.json`, publica os artefatos e registra o readiness de assinatura/notarizacao no summary.
+7. Depois da publicacao, rode `npm run release:verify -- --tag vX.Y.Z` para baixar feeds e assets da release real, validar `sha256` dos assets publicados e conferir `sha512`/`size` dos feeds.
 
 ## Garantia de builds no deploy
 
 As builds sao geradas no deploy de release (tags `vX.Y.Z`, `vX.Y.Z-beta.N`, `vX.Y.Z-rc.N` ou `workflow_dispatch` executado a partir da propria tag).
 
-O workflow `release.yml` roda em Windows, macOS e Linux e publica os artefatos no GitHub Release.
+O workflow `release.yml` roda em Windows, macOS e Linux, publica os artefatos no GitHub Release e encerra com uma verificacao automatica dos feeds e dos assets publicados.
 
 ## Notas da versao (site)
 

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -27,10 +27,13 @@
 10. Em release Linux, valide o feed do canal correto (`latest-linux.yml`, `beta-linux.yml` ou `rc-linux.yml`):
    - Deve listar os formatos publicados (`AppImage`, `.deb` e `.rpm`, quando houver).
    - Confirme `url`, `sha512` e `size` coerentes com os artefatos da release.
-11. Confirme no GitHub Release se a marcacao esta coerente:
+11. Depois que a tag publicar a release, rode `npm run release:verify -- --tag vX.Y.Z`:
+   - O script baixa os feeds e os assets referenciados, compara `sha256` dos assets publicados e valida `sha512`/`size` dos feeds.
+   - Use `--keep-temp` apenas se precisar inspecionar os downloads manualmente.
+12. Confirme no GitHub Release se a marcacao esta coerente:
    - `stable` nao deve sair como pre-release
    - `beta/rc` devem sair como pre-release
-12. Confira o summary do workflow para readiness de assinatura/notarizacao:
+13. Confira o summary do workflow para readiness de assinatura/notarizacao:
    - Se a release precisa sair assinada, habilite `REQUIRE_SIGNED_RELEASES=true`.
    - Se a release pode sair unsigned, confirme conscientemente o estado reportado.
-13. Atualize `docs/ATUALIZACOES.md` se houver mudanca no processo de release/deploy.
+14. Atualize `docs/ATUALIZACOES.md` se houver mudanca no processo de release/deploy.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "node scripts/test.js",
     "smoke:packaged": "node scripts/smoke-packaged.js",
     "release:notes": "node scripts/render-release-notes.js",
+    "release:verify": "node scripts/verify-release-assets.js",
     "reset": "node scripts/maintenance.js reset",
     "backup": "node scripts/maintenance.js backup",
     "clean": "node scripts/maintenance.js clean && npm i"

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -105,6 +105,12 @@ function loadPatchLinuxFeedModule() {
   return require(modulePath);
 }
 
+function loadReleaseVerifyModule() {
+  const modulePath = path.join(process.cwd(), 'scripts', 'verify-release-assets.js');
+  delete require.cache[require.resolve(modulePath)];
+  return require(modulePath);
+}
+
 function loadBotManagerModule(mockFork) {
   const modulePath = path.join(process.cwd(), 'src', 'main', 'botManager.js');
   delete require.cache[require.resolve(modulePath)];
@@ -442,6 +448,76 @@ test('release channel utility maps prerelease semver to RPM-safe version metadat
     release: '0.beta.4',
     isPrerelease: true,
   });
+});
+
+test('release verifier targets channel-specific linux feed while keeping shared desktop feeds', () => {
+  const { buildRequiredFeedNames } = loadReleaseVerifyModule();
+
+  assert.deepStrictEqual(buildRequiredFeedNames('v4.2.3'), [
+    'latest.yml',
+    'latest-mac.yml',
+    'latest-linux.yml',
+  ]);
+  assert.deepStrictEqual(buildRequiredFeedNames('v4.2.0-beta.4'), [
+    'latest.yml',
+    'latest-mac.yml',
+    'beta-linux.yml',
+  ]);
+});
+
+test('release verifier parses updater feeds without duplicating primary path entry', () => {
+  const { parseUpdaterFeed } = loadReleaseVerifyModule();
+  const parsed = parseUpdaterFeed(
+    [
+      'version: 4.2.3',
+      'files:',
+      '  - url: BotAssist-WhatsApp-4.2.3.AppImage',
+      '    sha512: appimage-hash',
+      '    size: 123',
+      '  - url: botassist-whatsapp_4.2.3_amd64.deb',
+      '    sha512: deb-hash',
+      '    size: 456',
+      'path: BotAssist-WhatsApp-4.2.3.AppImage',
+      'sha512: appimage-hash',
+      'releaseDate: 2026-03-22T09:00:00.000Z',
+      '',
+    ].join('\n')
+  );
+
+  assert.strictEqual(parsed.version, '4.2.3');
+  assert.deepStrictEqual(parsed.entries, [
+    {
+      url: 'BotAssist-WhatsApp-4.2.3.AppImage',
+      sha512: 'appimage-hash',
+      size: 123,
+    },
+    {
+      url: 'botassist-whatsapp_4.2.3_amd64.deb',
+      sha512: 'deb-hash',
+      size: 456,
+    },
+  ]);
+});
+
+test('release verifier requires rpm in linux feed when release publishes rpm asset', () => {
+  const { verifyLinuxFeedCoverage } = loadReleaseVerifyModule();
+  const assetMap = new Map([
+    ['BotAssist-WhatsApp-4.2.3.AppImage', { name: 'BotAssist-WhatsApp-4.2.3.AppImage' }],
+    ['botassist-whatsapp_4.2.3_amd64.deb', { name: 'botassist-whatsapp_4.2.3_amd64.deb' }],
+    ['botassist-whatsapp-4.2.3.x86_64.rpm', { name: 'botassist-whatsapp-4.2.3.x86_64.rpm' }],
+  ]);
+
+  assert.throws(() => {
+    verifyLinuxFeedCoverage(
+      {
+        entries: [
+          { url: 'BotAssist-WhatsApp-4.2.3.AppImage' },
+          { url: 'botassist-whatsapp_4.2.3_amd64.deb' },
+        ],
+      },
+      assetMap
+    );
+  }, /Feed Linux nao lista artefato \.rpm/);
 });
 
 test('linux feed patch can derive beta feed from latest-linux.yml', () => {

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+
+const crypto = require('crypto')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { execFileSync } = require('child_process')
+const { getReleaseChannelInfo, normalizeReleaseRef } = require('../src/shared/releaseChannel')
+
+const DEFAULT_REPO = 'N1ghthill/botassist-whatsapp'
+
+function parseArgs(argv) {
+  const args = {
+    repo: process.env.GITHUB_REPOSITORY || DEFAULT_REPO,
+    tag: process.env.RELEASE_TAG || '',
+    keepTemp: false,
+    retries: parsePositiveInt(process.env.RELEASE_VERIFY_RETRIES, 3),
+    retryDelayMs: parsePositiveInt(process.env.RELEASE_VERIFY_RETRY_DELAY_MS, 5000),
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = String(argv[index] || '')
+    const next = String(argv[index + 1] || '')
+
+    if ((current === '--repo' || current === '-R') && next) {
+      args.repo = next
+      index += 1
+      continue
+    }
+    if (current === '--tag' && next) {
+      args.tag = next
+      index += 1
+      continue
+    }
+    if (current === '--keep-temp') {
+      args.keepTemp = true
+      continue
+    }
+    if (current === '--retries' && next) {
+      args.retries = parsePositiveInt(next, args.retries)
+      index += 1
+      continue
+    }
+    if (current === '--retry-delay-ms' && next) {
+      args.retryDelayMs = parsePositiveInt(next, args.retryDelayMs)
+      index += 1
+    }
+  }
+
+  return args
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || '').trim(), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function formatCommandError(error) {
+  const stderr = String(error?.stderr || '').trim()
+  const stdout = String(error?.stdout || '').trim()
+  return stderr || stdout || error?.message || String(error)
+}
+
+function runGh(args) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    throw new Error(formatCommandError(error))
+  }
+}
+
+async function withRetries(label, fn, options) {
+  let lastError = null
+
+  for (let attempt = 1; attempt <= options.retries; attempt += 1) {
+    try {
+      return fn()
+    } catch (error) {
+      lastError = error
+      if (attempt >= options.retries) break
+      console.warn(
+        `[warn] ${label} failed (attempt ${attempt}/${options.retries}): ${error.message}. Retrying in ${options.retryDelayMs}ms.`
+      )
+      await sleep(options.retryDelayMs)
+    }
+  }
+
+  throw new Error(`${label} failed after ${options.retries} attempts: ${lastError?.message || 'unknown error'}`)
+}
+
+function loadReleaseInfo(tag, repo) {
+  return JSON.parse(
+    runGh([
+      'release',
+      'view',
+      tag,
+      '--repo',
+      repo,
+      '--json',
+      'tagName,isPrerelease,assets',
+    ])
+  )
+}
+
+function buildAssetMap(assets) {
+  const map = new Map()
+  for (const asset of Array.isArray(assets) ? assets : []) {
+    map.set(asset.name, asset)
+  }
+  return map
+}
+
+function buildRequiredFeedNames(tag) {
+  const channelInfo = getReleaseChannelInfo(tag)
+  return ['latest.yml', 'latest-mac.yml', channelInfo.feedFile]
+}
+
+function ensureReleaseTypeMatches(tag, releaseInfo) {
+  const channelInfo = getReleaseChannelInfo(tag)
+  if (Boolean(releaseInfo?.isPrerelease) !== channelInfo.isPrerelease) {
+    throw new Error(
+      `Tipo da release diverge da tag: esperado prerelease=${channelInfo.isPrerelease}, recebido prerelease=${Boolean(releaseInfo?.isPrerelease)}.`
+    )
+  }
+}
+
+function ensureAssetsExist(assetNames, assetMap, label) {
+  const missing = assetNames.filter((name) => !assetMap.has(name))
+  if (missing.length > 0) {
+    throw new Error(`${label} ausentes: ${missing.join(', ')}`)
+  }
+}
+
+function downloadReleaseAssets(tag, repo, targetDir, assetNames) {
+  if (!Array.isArray(assetNames) || assetNames.length === 0) return
+
+  const args = ['release', 'download', tag, '--repo', repo, '-D', targetDir]
+  for (const name of assetNames) {
+    args.push('-p', name)
+  }
+  runGh(args)
+}
+
+function ensureFeedEntry(entryMap, url) {
+  const normalizedUrl = String(url || '').trim()
+  if (!normalizedUrl) return null
+
+  if (!entryMap.has(normalizedUrl)) {
+    entryMap.set(normalizedUrl, {
+      url: normalizedUrl,
+      sha512: '',
+      size: null,
+    })
+  }
+
+  return entryMap.get(normalizedUrl)
+}
+
+function parseUpdaterFeed(content) {
+  const entryMap = new Map()
+  const lines = String(content || '').split(/\r?\n/)
+  let currentEntry = null
+  let version = ''
+
+  for (const line of lines) {
+    const versionMatch = line.match(/^version:\s+(.+)$/)
+    if (versionMatch) {
+      version = versionMatch[1].trim()
+      continue
+    }
+
+    const urlMatch = line.match(/^\s*-\s+url:\s+(.+)$/)
+    if (urlMatch) {
+      currentEntry = ensureFeedEntry(entryMap, urlMatch[1])
+      continue
+    }
+
+    const pathMatch = line.match(/^\s*path:\s+(.+)$/)
+    if (pathMatch) {
+      currentEntry = ensureFeedEntry(entryMap, pathMatch[1])
+      continue
+    }
+
+    const shaMatch = line.match(/^\s*sha512:\s+(.+)$/)
+    if (shaMatch && currentEntry) {
+      currentEntry.sha512 = shaMatch[1].trim()
+      continue
+    }
+
+    const sizeMatch = line.match(/^\s*size:\s+(\d+)$/)
+    if (sizeMatch && currentEntry) {
+      currentEntry.size = Number.parseInt(sizeMatch[1], 10)
+    }
+  }
+
+  return {
+    version,
+    entries: Array.from(entryMap.values()).filter((entry) => entry.url && entry.sha512),
+  }
+}
+
+function sha256Hex(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+function sha512Base64(filePath) {
+  return crypto.createHash('sha512').update(fs.readFileSync(filePath)).digest('base64')
+}
+
+function verifyDownloadedAssetDigests(targetDir, assetMap, assetNames) {
+  for (const name of assetNames) {
+    const filePath = path.join(targetDir, name)
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Arquivo baixado nao encontrado: ${name}`)
+    }
+
+    const asset = assetMap.get(name)
+    const digest = String(asset?.digest || '').trim()
+    if (digest.startsWith('sha256:')) {
+      const expected = digest.replace(/^sha256:/, '')
+      const actual = sha256Hex(filePath)
+      if (actual !== expected) {
+        throw new Error(`SHA256 divergente para ${name}`)
+      }
+    }
+  }
+}
+
+function verifyFeedVersion(feedName, parsedFeed, tag) {
+  const expectedVersion = normalizeReleaseRef(tag)
+  if (parsedFeed.version !== expectedVersion) {
+    throw new Error(`${feedName} aponta para versao ${parsedFeed.version}, esperado ${expectedVersion}`)
+  }
+}
+
+function verifyLinuxFeedCoverage(parsedFeed, assetMap) {
+  const expectedSuffixes = ['.AppImage', '.deb']
+  const hasRpmAsset = Array.from(assetMap.keys()).some((name) => name.endsWith('.rpm'))
+  if (hasRpmAsset) {
+    expectedSuffixes.push('.rpm')
+  }
+
+  for (const suffix of expectedSuffixes) {
+    const hasEntry = parsedFeed.entries.some((entry) => entry.url.endsWith(suffix))
+    if (!hasEntry) {
+      throw new Error(`Feed Linux nao lista artefato ${suffix}`)
+    }
+  }
+}
+
+function verifyFeedEntries(feedName, parsedFeed, assetMap, targetDir) {
+  if (!Array.isArray(parsedFeed.entries) || parsedFeed.entries.length === 0) {
+    throw new Error(`${feedName} nao contem arquivos verificaveis`)
+  }
+
+  for (const entry of parsedFeed.entries) {
+    const asset = assetMap.get(entry.url)
+    if (!asset) {
+      throw new Error(`${feedName} referencia asset ausente: ${entry.url}`)
+    }
+
+    const filePath = path.join(targetDir, entry.url)
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Asset referenciado por ${feedName} nao foi baixado: ${entry.url}`)
+    }
+
+    if (Number.isFinite(entry.size)) {
+      const actualSize = fs.statSync(filePath).size
+      if (actualSize !== entry.size) {
+        throw new Error(`${feedName} informa size divergente para ${entry.url}`)
+      }
+    }
+
+    const actualSha512 = sha512Base64(filePath)
+    if (actualSha512 !== entry.sha512) {
+      throw new Error(`${feedName} informa sha512 divergente para ${entry.url}`)
+    }
+  }
+}
+
+function cleanupTempDir(targetDir) {
+  if (!targetDir) return
+  try {
+    fs.rmSync(targetDir, { recursive: true, force: true })
+  } catch (error) {
+    console.warn(`[warn] Falha ao limpar diretorio temporario ${targetDir}: ${error.message}`)
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!String(args.tag || '').trim()) {
+    throw new Error('Informe a tag da release com --tag ou RELEASE_TAG.')
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'botassist-release-verify-'))
+
+  try {
+    const releaseInfo = await withRetries(
+      'Carregar metadata da release',
+      () => loadReleaseInfo(args.tag, args.repo),
+      args
+    )
+
+    ensureReleaseTypeMatches(args.tag, releaseInfo)
+
+    const assetMap = buildAssetMap(releaseInfo.assets)
+    const feedNames = buildRequiredFeedNames(args.tag)
+    const linuxFeedName = feedNames[feedNames.length - 1]
+
+    ensureAssetsExist(feedNames, assetMap, 'Feeds obrigatorios')
+    await withRetries(
+      'Baixar feeds da release',
+      () => downloadReleaseAssets(args.tag, args.repo, tempDir, feedNames),
+      args
+    )
+    verifyDownloadedAssetDigests(tempDir, assetMap, feedNames)
+
+    const parsedFeeds = new Map()
+    for (const feedName of feedNames) {
+      const parsedFeed = parseUpdaterFeed(fs.readFileSync(path.join(tempDir, feedName), 'utf8'))
+      verifyFeedVersion(feedName, parsedFeed, args.tag)
+      if (feedName === linuxFeedName) {
+        verifyLinuxFeedCoverage(parsedFeed, assetMap)
+      }
+      parsedFeeds.set(feedName, parsedFeed)
+    }
+
+    const referencedAssetNames = Array.from(
+      new Set(
+        Array.from(parsedFeeds.values()).flatMap((parsedFeed) => parsedFeed.entries.map((entry) => entry.url))
+      )
+    )
+
+    ensureAssetsExist(referencedAssetNames, assetMap, 'Assets referenciados pelos feeds')
+    await withRetries(
+      'Baixar assets referenciados pelos feeds',
+      () => downloadReleaseAssets(args.tag, args.repo, tempDir, referencedAssetNames),
+      args
+    )
+    verifyDownloadedAssetDigests(tempDir, assetMap, referencedAssetNames)
+
+    for (const [feedName, parsedFeed] of parsedFeeds.entries()) {
+      verifyFeedEntries(feedName, parsedFeed, assetMap, tempDir)
+    }
+
+    console.log(
+      `Release ${args.tag} verificada com sucesso: ${feedNames.length} feeds e ${referencedAssetNames.length} assets conferidos.`
+    )
+    if (args.keepTemp) {
+      console.log(`Diretorio temporario preservado em ${tempDir}`)
+      return
+    }
+  } finally {
+    if (!args.keepTemp) {
+      cleanupTempDir(tempDir)
+    }
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error?.message || String(error))
+    process.exitCode = 1
+  })
+}
+
+module.exports = {
+  buildRequiredFeedNames,
+  parseArgs,
+  parseUpdaterFeed,
+  verifyLinuxFeedCoverage,
+}


### PR DESCRIPTION
## Summary

This PR makes the release flow safer without changing the existing packaging logic.

- adds a dedicated `release:verify` script that downloads the published release assets and feeds
- validates release type, feed version, SHA256 asset digests, and SHA512/size entries in updater feeds
- cleans up its temporary download directory automatically by default
- adds a final `verify-release` job to the release workflow
- documents the command in the release checklist and update guide
- adds lightweight tests for feed selection/parsing and Linux RPM coverage

## Validation

- `npm test`
- `npm run lint`
- `npm run release:verify -- --tag v4.2.3`
- `npm run release:verify -- --tag v4.2.0-beta.4`

## Risk

Low.

- no change to build targets or publish commands
- verification runs after assets are already published
- stable and prerelease feed paths were both validated against real releases
