### PR TITLE
Refresh public docs for 4.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ O BotAssist nasceu como um app pessoal, mas hoje a proposta do repo e mais clara
 
 ## Estado atual
 
-- Canal preparado no repo: `4.2.2`
-- Release estavel ativa: `v4.2.2`
-- Canal beta continua reservado para validar refatoracoes maiores antes da proxima stable
+- Linha publicada no repo: `4.2.3`
+- Release estavel ativa: `v4.2.3`
+- Validacao de release fechada com `lint`, `test`, build Linux, smoke empacotado e `release:verify`
 
 ## Comece em 5 minutos
 
@@ -124,7 +124,8 @@ Validacoes locais:
 ```bash
 npm test
 npm run lint
-npm run release:notes -- --tag v4.2.2 --title-only
+npm run release:notes -- --tag vX.Y.Z --title-only
+npm run release:verify -- --tag vX.Y.Z
 ```
 
 Builds:
@@ -147,7 +148,7 @@ O projeto agora separa canais:
 - `vX.Y.Z-beta.N`: beta
 - `vX.Y.Z-rc.N`: release candidate
 
-O updater segue o mesmo canal da versao instalada. O processo operacional esta em [docs/ATUALIZACOES.md](docs/ATUALIZACOES.md) e a checklist em [docs/RELEASE-CHECKLIST.md](docs/RELEASE-CHECKLIST.md).
+O updater segue o mesmo canal da versao instalada. O processo operacional esta em [docs/ATUALIZACOES.md](docs/ATUALIZACOES.md), a checklist em [docs/RELEASE-CHECKLIST.md](docs/RELEASE-CHECKLIST.md) e a verificacao pos-publicacao usa `npm run release:verify`.
 
 ## Capturas
 

--- a/docs/ATUALIZACOES.md
+++ b/docs/ATUALIZACOES.md
@@ -37,7 +37,7 @@ Voce precisa:
 
 ### Passo a passo (exemplo)
 
-1. Atualize a versao no `package.json` com o canal correto (ex.: `4.2.0`, `4.2.2-beta.1`, `4.2.2-rc.1`).
+1. Atualize a versao no `package.json` com o canal correto (ex.: `4.2.3`, `4.2.3-beta.1`, `4.2.3-rc.1`).
 2. Atualize as notas da release:
    - `docs/notas-da-versao.json` (fonte estruturada para site/automacoes)
    - `docs/NOTAS-DA-VERSAO.md` (texto editorial)
@@ -85,6 +85,14 @@ Detalhes operacionais em `docs/ASSINATURA-E-NOTARIZACAO.md`.
 - O workflow de release usa o `GITHUB_TOKEN` do proprio GitHub Actions para publicar releases.
 - No Linux, o release publica `AppImage`, `.deb` e `.rpm`.
 - O feed Linux publicado segue o canal da release: `latest-linux.yml`, `beta-linux.yml` ou `rc-linux.yml`.
+
+## Registro recente (2026-03-22)
+
+- Release formal `4.2.3` com modularizacao incremental do runtime e hardening do subsistema de tools.
+- `bot.js` perdeu concentracao de responsabilidade com extracao de comandos e approval flow.
+- Contratos de IPC/eventos foram centralizados em modulo compartilhado.
+- Normalizacao de settings passou a ficar mais consistente entre `main`, `core` e `renderer`.
+- Publicacao agora pode ser fechada com `npm run release:verify`, que confere feeds e assets reais da release publicada.
 
 ## Registro recente (2026-03-21)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,8 +4,9 @@ Bem-vindo(a) ao conjunto de documentos oficiais do BotAssist.
 
 Estado atual do repositorio:
 
-- linha de release preparada: `4.2.2`
+- release estavel publicada: `v4.2.3`
 - canal estavel continua separado de `beta` e `rc`
+- verificacao pos-release automatizada ja faz parte do fluxo
 - `README.md` e o ponto de entrada recomendado para quem chega no projeto
 
 ## Comece por aqui


### PR DESCRIPTION
## Summary

Refresh the public-facing docs to match the latest stable release.

- updates README release state to `v4.2.3`
- replaces stale version-specific release commands with generic forms
- points README to the new `release:verify` post-publish step
- updates docs index to reflect the current stable line
- adds the `4.2.3` release summary to the release/update guide

## Notes

- no tracked legacy/temporary files were found that justified deletion
- this PR only removes stale documentation drift

## Validation

- `npm test`
