### PR TITLE
feat: publish release manifest for site sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,5 +184,11 @@ jobs:
         with:
           node-version: 22
 
+      - name: Render release manifest
+        run: node scripts/render-release-manifest.js --tag "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --include-assets --output release-manifest.json
+
+      - name: Upload release manifest
+        run: gh release upload "${RELEASE_TAG}" release-manifest.json --clobber
+
       - name: Verify published release assets and feeds
         run: npm run release:verify -- --tag "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:check": "prettier --check \"src/**/*.{js,css,html,json,md}\"",
     "test": "node scripts/test.js",
     "smoke:packaged": "node scripts/smoke-packaged.js",
+    "release:manifest": "node scripts/render-release-manifest.js",
     "release:notes": "node scripts/render-release-notes.js",
     "release:signing:check": "node scripts/check-signing-readiness.js",
     "release:signing:provision": "node scripts/provision-signing-secrets.js",

--- a/scripts/render-release-manifest.js
+++ b/scripts/render-release-manifest.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const { execFileSync } = require('child_process')
+const { getReleaseChannelInfo } = require('../src/shared/releaseChannel')
+
+const RELEASE_NOTES_FILE = path.resolve(__dirname, '..', 'docs', 'notas-da-versao.json')
+const DEFAULT_REPO = 'N1ghthill/botassist-whatsapp'
+const RELEASE_MANIFEST_FILE = 'release-manifest.json'
+
+const DEFAULT_REQUIREMENTS = {
+  windows: 'Windows 10/11 64-bit',
+  mac: 'macOS 12+ (Monterey)',
+  linux: 'Linux x64 moderno',
+}
+
+const DEFAULT_DOWNLOAD_FORMATS = {
+  windows: 'Setup.exe + build portatil',
+  mac: 'DMG arm64',
+  linux: 'AppImage, DEB e RPM',
+}
+
+function parseArgs(argv) {
+  const args = {
+    repo: process.env.GITHUB_REPOSITORY || DEFAULT_REPO,
+    tag: process.env.RELEASE_TAG || '',
+    output: '',
+    includeAssets: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = String(argv[index] || '')
+    const next = String(argv[index + 1] || '')
+
+    if (current === '--repo' && next) {
+      args.repo = next
+      index += 1
+      continue
+    }
+    if (current === '--tag' && next) {
+      args.tag = next
+      index += 1
+      continue
+    }
+    if (current === '--output' && next) {
+      args.output = next
+      index += 1
+      continue
+    }
+    if (current === '--include-assets') {
+      args.includeAssets = true
+    }
+  }
+
+  return args
+}
+
+function stripTagPrefix(value) {
+  return String(value || '').trim().replace(/^v/i, '')
+}
+
+function loadNotes() {
+  return JSON.parse(fs.readFileSync(RELEASE_NOTES_FILE, 'utf8'))
+}
+
+function findRelease(data, version) {
+  return Array.isArray(data?.releases)
+    ? data.releases.find((entry) => String(entry?.version || '').trim() === version)
+    : null
+}
+
+function buildBadge(channelInfo) {
+  if (channelInfo.channel === 'latest') return 'Release estavel'
+  if (channelInfo.channel === 'rc') return 'Release candidate'
+  if (channelInfo.channel === 'beta') return 'Beta publica'
+  return `Canal ${channelInfo.channel}`
+}
+
+function buildCardsFromHighlights(highlights) {
+  return (Array.isArray(highlights) ? highlights : []).slice(0, 3).map((description, index) => ({
+    title: `Highlight ${index + 1}`,
+    description: String(description || '').trim(),
+  }))
+}
+
+function runGh(args) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    const stderr = String(error?.stderr || '').trim()
+    const stdout = String(error?.stdout || '').trim()
+    throw new Error(stderr || stdout || error?.message || String(error))
+  }
+}
+
+function loadReleaseInfo(repo, tag) {
+  return JSON.parse(
+    runGh([
+      'release',
+      'view',
+      tag,
+      '--repo',
+      repo,
+      '--json',
+      'tagName,isPrerelease,publishedAt,assets',
+    ])
+  )
+}
+
+function normalizeAsset(asset) {
+  return {
+    name: String(asset?.name || '').trim(),
+    url: String(asset?.url || '').trim(),
+    size: Number.isFinite(asset?.size) ? asset.size : null,
+    contentType: String(asset?.contentType || '').trim(),
+    digest: String(asset?.digest || '').trim(),
+  }
+}
+
+function isMetadataAsset(name) {
+  return (
+    String(name || '').endsWith('.blockmap') ||
+    String(name || '').endsWith('.yml') ||
+    String(name || '') === RELEASE_MANIFEST_FILE
+  )
+}
+
+function pickFirstAsset(assets, predicate) {
+  return assets.find((asset) => predicate(String(asset?.name || '').trim())) || null
+}
+
+function pickPrimaryDownloads(assets) {
+  const fileAssets = (Array.isArray(assets) ? assets : [])
+    .map(normalizeAsset)
+    .filter((asset) => asset.name && !isMetadataAsset(asset.name))
+
+  const windowsPrimary =
+    pickFirstAsset(fileAssets, (name) => /Setup-.*\.exe$/i.test(name)) ||
+    pickFirstAsset(fileAssets, (name) => /\.exe$/i.test(name))
+  const macPrimary = pickFirstAsset(fileAssets, (name) => /\.dmg$/i.test(name))
+  const linuxPrimary =
+    pickFirstAsset(fileAssets, (name) => /\.AppImage$/i.test(name)) ||
+    pickFirstAsset(fileAssets, (name) => /\.deb$/i.test(name)) ||
+    pickFirstAsset(fileAssets, (name) => /\.rpm$/i.test(name))
+
+  return {
+    windows: windowsPrimary
+      ? {
+          url: windowsPrimary.url,
+          path: windowsPrimary.name,
+          asset: windowsPrimary.name,
+        }
+      : null,
+    mac: macPrimary
+      ? {
+          url: macPrimary.url,
+          path: macPrimary.name,
+          asset: macPrimary.name,
+        }
+      : null,
+    linux: linuxPrimary
+      ? {
+          url: linuxPrimary.url,
+          path: linuxPrimary.name,
+          asset: linuxPrimary.name,
+          alternatives: fileAssets
+            .filter((asset) => asset.name !== linuxPrimary.name && /\.(AppImage|deb|rpm)$/i.test(asset.name))
+            .map((asset) => ({
+              url: asset.url,
+              path: asset.name,
+              asset: asset.name,
+            })),
+        }
+      : null,
+  }
+}
+
+function renderManifest({ repo, tag, includeAssets }) {
+  const version = stripTagPrefix(tag)
+  if (!version) {
+    throw new Error('Informe a tag da release com --tag ou RELEASE_TAG.')
+  }
+
+  const notes = loadNotes()
+  const release = findRelease(notes, version)
+  if (!release) {
+    throw new Error(`Versao ${version} nao encontrada em docs/notas-da-versao.json.`)
+  }
+
+  const channelInfo = getReleaseChannelInfo(tag)
+  const releaseInfo = includeAssets ? loadReleaseInfo(repo, tag) : null
+  const normalizedAssets = Array.isArray(releaseInfo?.assets)
+    ? releaseInfo.assets.map(normalizeAsset)
+    : []
+  const cards =
+    Array.isArray(release?.cards) && release.cards.length > 0
+      ? release.cards.slice(0, 3)
+      : buildCardsFromHighlights(release?.highlights)
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    repo,
+    tag: String(tag || '').trim(),
+    version,
+    channel: channelInfo.channel,
+    isPrerelease: channelInfo.isPrerelease,
+    badge: String(release?.badge || '').trim() || buildBadge(channelInfo),
+    date: String(release?.date || releaseInfo?.publishedAt || '').trim(),
+    title: String(release?.title || version).trim(),
+    summary: String(release?.summary || '').trim(),
+    cards,
+    highlights: Array.isArray(release?.highlights) ? release.highlights : [],
+    requirements: {
+      ...DEFAULT_REQUIREMENTS,
+      ...(release?.requirements || {}),
+    },
+    downloadFormats: {
+      ...DEFAULT_DOWNLOAD_FORMATS,
+      ...(release?.downloadFormats || {}),
+    },
+    downloads: pickPrimaryDownloads(normalizedAssets),
+    assets: normalizedAssets,
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const manifest = renderManifest(args)
+  const output = `${JSON.stringify(manifest, null, 2)}\n`
+
+  if (args.output) {
+    fs.writeFileSync(path.resolve(args.output), output, 'utf8')
+  } else {
+    process.stdout.write(output)
+  }
+}
+
+if (require.main === module) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error?.message || String(error))
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  RELEASE_MANIFEST_FILE,
+  buildBadge,
+  buildCardsFromHighlights,
+  parseArgs,
+  pickPrimaryDownloads,
+  renderManifest,
+}

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -123,6 +123,12 @@ function loadReleaseVerifyModule() {
   return require(modulePath);
 }
 
+function loadReleaseManifestModule() {
+  const modulePath = path.join(process.cwd(), 'scripts', 'render-release-manifest.js');
+  delete require.cache[require.resolve(modulePath)];
+  return require(modulePath);
+}
+
 function loadSigningReadinessModule() {
   const modulePath = path.join(process.cwd(), 'scripts', 'check-signing-readiness.js');
   delete require.cache[require.resolve(modulePath)];
@@ -646,6 +652,71 @@ test('release verifier parses updater feeds without duplicating primary path ent
   ]);
 });
 
+test('release manifest picks direct downloads from published assets', () => {
+  const { pickPrimaryDownloads } = loadReleaseManifestModule();
+  const downloads = pickPrimaryDownloads([
+    { name: 'BotAssist-WhatsApp-4.2.4-arm64.dmg', url: 'https://example.com/app.dmg' },
+    { name: 'BotAssist-WhatsApp-Setup-4.2.4.exe', url: 'https://example.com/setup.exe' },
+    { name: 'BotAssist-WhatsApp-4.2.4.exe', url: 'https://example.com/portable.exe' },
+    { name: 'BotAssist-WhatsApp-4.2.4.AppImage', url: 'https://example.com/appimage' },
+    { name: 'botassist-whatsapp_4.2.4_amd64.deb', url: 'https://example.com/deb' },
+    { name: 'botassist-whatsapp-4.2.4.x86_64.rpm', url: 'https://example.com/rpm' },
+    { name: 'latest.yml', url: 'https://example.com/latest.yml' },
+  ]);
+
+  assert.deepStrictEqual(downloads, {
+    windows: {
+      url: 'https://example.com/setup.exe',
+      path: 'BotAssist-WhatsApp-Setup-4.2.4.exe',
+      asset: 'BotAssist-WhatsApp-Setup-4.2.4.exe',
+    },
+    mac: {
+      url: 'https://example.com/app.dmg',
+      path: 'BotAssist-WhatsApp-4.2.4-arm64.dmg',
+      asset: 'BotAssist-WhatsApp-4.2.4-arm64.dmg',
+    },
+    linux: {
+      url: 'https://example.com/appimage',
+      path: 'BotAssist-WhatsApp-4.2.4.AppImage',
+      asset: 'BotAssist-WhatsApp-4.2.4.AppImage',
+      alternatives: [
+        {
+          url: 'https://example.com/deb',
+          path: 'botassist-whatsapp_4.2.4_amd64.deb',
+          asset: 'botassist-whatsapp_4.2.4_amd64.deb',
+        },
+        {
+          url: 'https://example.com/rpm',
+          path: 'botassist-whatsapp-4.2.4.x86_64.rpm',
+          asset: 'botassist-whatsapp-4.2.4.x86_64.rpm',
+        },
+      ],
+    },
+  });
+});
+
+test('release manifest renders stable metadata from notes with fallback badge', () => {
+  const { renderManifest } = loadReleaseManifestModule();
+  const manifest = renderManifest({
+    repo: 'N1ghthill/botassist-whatsapp',
+    tag: 'v4.2.4',
+    includeAssets: false,
+  });
+
+  assert.strictEqual(manifest.version, '4.2.4');
+  assert.strictEqual(manifest.channel, 'latest');
+  assert.strictEqual(manifest.isPrerelease, false);
+  assert.strictEqual(manifest.badge, 'Release estavel');
+  assert.strictEqual(manifest.title, 'Saneamento de dependencias e fechamento do patch de release');
+  assert.ok(Array.isArray(manifest.cards));
+  assert.ok(manifest.cards.length >= 1);
+  assert.deepStrictEqual(manifest.requirements, {
+    windows: 'Windows 10/11 64-bit',
+    mac: 'macOS 12+ (Monterey)',
+    linux: 'Linux x64 moderno',
+  });
+});
+
 test('release verifier requires rpm in linux feed when release publishes rpm asset', () => {
   const { verifyLinuxFeedCoverage } = loadReleaseVerifyModule();
   const assetMap = new Map([
@@ -665,6 +736,42 @@ test('release verifier requires rpm in linux feed when release publishes rpm ass
       assetMap
     );
   }, /Feed Linux nao lista artefato \.rpm/);
+});
+
+test('release verifier validates manifest version and referenced downloads', () => {
+  const { verifyManifestDownloads, verifyManifestVersion } = loadReleaseVerifyModule();
+  const assetMap = new Map([
+    ['BotAssist-WhatsApp-Setup-4.2.4.exe', { name: 'BotAssist-WhatsApp-Setup-4.2.4.exe' }],
+    ['BotAssist-WhatsApp-4.2.4-arm64.dmg', { name: 'BotAssist-WhatsApp-4.2.4-arm64.dmg' }],
+    ['BotAssist-WhatsApp-4.2.4.AppImage', { name: 'BotAssist-WhatsApp-4.2.4.AppImage' }],
+    ['botassist-whatsapp_4.2.4_amd64.deb', { name: 'botassist-whatsapp_4.2.4_amd64.deb' }],
+  ]);
+  const manifest = {
+    version: '4.2.4',
+    downloads: {
+      windows: {
+        url: 'https://example.com/BotAssist-WhatsApp-Setup-4.2.4.exe',
+        path: 'BotAssist-WhatsApp-Setup-4.2.4.exe',
+      },
+      mac: {
+        url: 'https://example.com/BotAssist-WhatsApp-4.2.4-arm64.dmg',
+        path: 'BotAssist-WhatsApp-4.2.4-arm64.dmg',
+      },
+      linux: {
+        url: 'https://example.com/BotAssist-WhatsApp-4.2.4.AppImage',
+        path: 'BotAssist-WhatsApp-4.2.4.AppImage',
+        alternatives: [
+          {
+            url: 'https://example.com/botassist-whatsapp_4.2.4_amd64.deb',
+            path: 'botassist-whatsapp_4.2.4_amd64.deb',
+          },
+        ],
+      },
+    },
+  };
+
+  verifyManifestVersion(manifest, 'v4.2.4');
+  verifyManifestDownloads(manifest, assetMap);
 });
 
 test('signing readiness accepts imported certificates and notarization API credentials', () => {

--- a/scripts/verify-release-assets.js
+++ b/scripts/verify-release-assets.js
@@ -8,6 +8,7 @@ const { execFileSync } = require('child_process')
 const { getReleaseChannelInfo, normalizeReleaseRef } = require('../src/shared/releaseChannel')
 
 const DEFAULT_REPO = 'N1ghthill/botassist-whatsapp'
+const RELEASE_MANIFEST_FILE = 'release-manifest.json'
 
 function parseArgs(argv) {
   const args = {
@@ -120,6 +121,10 @@ function buildAssetMap(assets) {
 function buildRequiredFeedNames(tag) {
   const channelInfo = getReleaseChannelInfo(tag)
   return ['latest.yml', 'latest-mac.yml', channelInfo.feedFile]
+}
+
+function parseReleaseManifest(content) {
+  return JSON.parse(String(content || ''))
 }
 
 function ensureReleaseTypeMatches(tag, releaseInfo) {
@@ -240,6 +245,43 @@ function verifyFeedVersion(feedName, parsedFeed, tag) {
   }
 }
 
+function verifyManifestVersion(manifest, tag) {
+  const expectedVersion = normalizeReleaseRef(tag)
+  if (String(manifest?.version || '').trim() !== expectedVersion) {
+    throw new Error(
+      `release-manifest.json aponta para versao ${String(manifest?.version || '').trim()}, esperado ${expectedVersion}`
+    )
+  }
+}
+
+function verifyManifestDownloadEntry(entry, assetMap, label) {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error(`release-manifest.json nao contem download primario de ${label}`)
+  }
+
+  const pathValue = String(entry.path || entry.asset || '').trim()
+  const urlValue = String(entry.url || '').trim()
+  if (!pathValue || !urlValue) {
+    throw new Error(`release-manifest.json possui download invalido de ${label}`)
+  }
+  if (!assetMap.has(pathValue)) {
+    throw new Error(`release-manifest.json referencia asset inexistente para ${label}: ${pathValue}`)
+  }
+}
+
+function verifyManifestDownloads(manifest, assetMap) {
+  const downloads = manifest?.downloads || {}
+
+  verifyManifestDownloadEntry(downloads.windows, assetMap, 'Windows')
+  verifyManifestDownloadEntry(downloads.mac, assetMap, 'macOS')
+  verifyManifestDownloadEntry(downloads.linux, assetMap, 'Linux')
+
+  const alternatives = Array.isArray(downloads?.linux?.alternatives) ? downloads.linux.alternatives : []
+  for (const alternative of alternatives) {
+    verifyManifestDownloadEntry(alternative, assetMap, 'Linux')
+  }
+}
+
 function verifyLinuxFeedCoverage(parsedFeed, assetMap) {
   const expectedSuffixes = ['.AppImage', '.deb']
   const hasRpmAsset = Array.from(assetMap.keys()).some((name) => name.endsWith('.rpm'))
@@ -313,15 +355,22 @@ async function main() {
 
     const assetMap = buildAssetMap(releaseInfo.assets)
     const feedNames = buildRequiredFeedNames(args.tag)
+    const metadataAssetNames = [...feedNames, RELEASE_MANIFEST_FILE]
     const linuxFeedName = feedNames[feedNames.length - 1]
 
-    ensureAssetsExist(feedNames, assetMap, 'Feeds obrigatorios')
+    ensureAssetsExist(metadataAssetNames, assetMap, 'Arquivos de metadata obrigatorios')
     await withRetries(
-      'Baixar feeds da release',
-      () => downloadReleaseAssets(args.tag, args.repo, tempDir, feedNames),
+      'Baixar metadata da release',
+      () => downloadReleaseAssets(args.tag, args.repo, tempDir, metadataAssetNames),
       args
     )
-    verifyDownloadedAssetDigests(tempDir, assetMap, feedNames)
+    verifyDownloadedAssetDigests(tempDir, assetMap, metadataAssetNames)
+
+    const parsedManifest = parseReleaseManifest(
+      fs.readFileSync(path.join(tempDir, RELEASE_MANIFEST_FILE), 'utf8')
+    )
+    verifyManifestVersion(parsedManifest, args.tag)
+    verifyManifestDownloads(parsedManifest, assetMap)
 
     const parsedFeeds = new Map()
     for (const feedName of feedNames) {
@@ -375,6 +424,9 @@ if (require.main === module) {
 module.exports = {
   buildRequiredFeedNames,
   parseArgs,
+  parseReleaseManifest,
   parseUpdaterFeed,
+  verifyManifestDownloads,
+  verifyManifestVersion,
   verifyLinuxFeedCoverage,
 }


### PR DESCRIPTION
## Summary
- generate a release-manifest.json from release notes and published assets
- upload the manifest during release verification and validate it alongside updater feeds
- add tests covering manifest rendering and asset verification

Closes #26